### PR TITLE
[AJO-22] 로그인 기능 Init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,16 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    runtimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/src/main/java/com/ajouevent/admin/App.java
+++ b/src/main/java/com/ajouevent/admin/App.java
@@ -1,5 +1,4 @@
-package org.example;
-
+package com.ajouevent.admin;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/src/main/java/com/ajouevent/admin/config/SecurityConfig.java
+++ b/src/main/java/com/ajouevent/admin/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.ajouevent.admin.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    // ✅ 비밀번호 인코더 등록
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // ✅ API 인증 정책 설정
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf().disable() // CSRF 보호 끔 (API 서버일 경우)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll() // 모든 요청 허용
+                        // .requestMatchers("/api/admin/**").permitAll() // 이렇게 특정 경로만 허용도 가능
+                        .anyRequest().permitAll()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/ajouevent/admin/controller/AdminUserController.java
+++ b/src/main/java/com/ajouevent/admin/controller/AdminUserController.java
@@ -1,0 +1,29 @@
+package com.ajouevent.admin.controller;
+
+import com.ajouevent.admin.dto.request.SignUpRequest;
+import com.ajouevent.admin.dto.request.LoginRequest;
+import com.ajouevent.admin.dto.response.AdminAuthResponse;
+import com.ajouevent.admin.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<AdminAuthResponse> signUp(@RequestBody SignUpRequest request) {
+        AdminAuthResponse response = adminUserService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AdminAuthResponse> login(@RequestBody LoginRequest request) {
+        AdminAuthResponse response = adminUserService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ajouevent/admin/domain/AdminUser.java
+++ b/src/main/java/com/ajouevent/admin/domain/AdminUser.java
@@ -1,0 +1,35 @@
+package com.ajouevent.admin.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class AdminUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "user_nickname", nullable = false)
+    private String userNickname;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ajouevent/admin/domain/ClubEvent.java
+++ b/src/main/java/com/ajouevent/admin/domain/ClubEvent.java
@@ -1,0 +1,95 @@
+package com.ajouevent.admin.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ClubEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long eventId;
+
+    @Column
+    private String title;
+
+    @Column(length = 50000)
+    private String content;
+
+    @Column // 게시글 작성자(작성 기관)
+    private String writer;
+
+    @Column // 게시글 생성 시간
+    private LocalDateTime createdAt;
+
+    @Column // 게시글 분류(topic) - 아주대학교 - 일반, 소프트웨어학과, 동아리
+    private String subject;
+
+    @Column // 원래 공지사항 url
+    private String url;
+
+    @Column // 찜한 수 (default는 0)
+    private Long likesCount;
+
+    @Column // 조회 수 (default는 0)
+    private Long viewCount;
+
+//    @Column(length = 50000)
+//    @Enumerated(value = EnumType.STRING)
+//    private Type type;
+
+//    @BatchSize(size=100) //
+//    @OneToMany(mappedBy = "clubEvent", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+//    @ToString.Exclude
+//    private List<ClubEventImage> clubEventImageList;
+
+//    public void updateEvent(UpdateEventRequest request) {
+//        if (request.getTitle() != null) {
+//            this.title = request.getTitle();
+//        }
+//        if (request.getContent() != null) {
+//            this.content = request.getContent();
+//        }
+//        if (request.getWriter() != null) {
+//            this.writer = request.getWriter();
+//        }
+//        if (request.getSubject() != null) {
+//            this.subject = request.getSubject();
+//        }
+//        if (request.getUrl() != null) {
+//            this.url = request.getUrl();
+//        }
+//        if (request.getType() != null) {
+//            this.type = request.getType();
+//        }
+//        // date는 일반적으로 업데이트 요청 시 현재 시간으로 설정하는 것이 일반적이므로 주석 처리
+//        this.createdAt = LocalDateTime.now();
+//    }
+
+    // 게시글의 저장수 증가
+    public void incrementLikes() {
+        this.likesCount++;
+    }
+
+    // 게시글의 저장수 감소
+    public void decreaseLikes() {
+        this.likesCount--;
+    }
+
+    // // 게시글의 조회수 증가
+    // public void increaseViewCount() {
+    //     this.viewCount++; // 조회수 증가
+    // }
+
+
+}

--- a/src/main/java/com/ajouevent/admin/domain/EventLike.java
+++ b/src/main/java/com/ajouevent/admin/domain/EventLike.java
@@ -1,0 +1,41 @@
+package com.ajouevent.admin.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@Table(name = "event_like_table")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EventLike {
+
+    @Id // pk 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long eventLikeId;
+
+    @ManyToOne
+    @JoinColumn(name = "club_event_id")
+    private ClubEvent clubEvent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/com/ajouevent/admin/domain/Member.java
+++ b/src/main/java/com/ajouevent/admin/domain/Member.java
@@ -1,0 +1,67 @@
+package com.ajouevent.admin.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, unique = true)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column
+    private String name;
+
+    @Column
+    private String password;
+
+    @Column
+    private String major;
+
+    @Column
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,
+//            CascadeType.REMOVE}, orphanRemoval = true)
+//    private List<Token> tokens;
+//
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+//    @ToString.Exclude
+//    private List<Alarm> alarmList;
+
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,
+//            CascadeType.REMOVE}, orphanRemoval = true)
+//    private List<EventLike> eventLikeList;
+
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,
+//            CascadeType.REMOVE}, orphanRemoval = true)
+//    private List<TopicMember> topicMembers;
+//
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,
+//            CascadeType.REMOVE}, orphanRemoval = true)
+//    private List<KeywordMember> keywordMembers;
+
+    @Builder
+    public Member(Long id, String email, String name, String password, String major, String phone, Role role) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.major = major;
+        this.phone = phone;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/ajouevent/admin/domain/Role.java
+++ b/src/main/java/com/ajouevent/admin/domain/Role.java
@@ -1,0 +1,10 @@
+package com.ajouevent.admin.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    USER,
+    LEADER,
+//    ADMIN
+}

--- a/src/main/java/com/ajouevent/admin/dto/request/LoginRequest.java
+++ b/src/main/java/com/ajouevent/admin/dto/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.ajouevent.admin.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/ajouevent/admin/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ajouevent/admin/dto/request/SignUpRequest.java
@@ -1,0 +1,12 @@
+package com.ajouevent.admin.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignUpRequest {
+    private String email;
+    private String password;
+    private String userNickname;
+}

--- a/src/main/java/com/ajouevent/admin/dto/response/AdminAuthResponse.java
+++ b/src/main/java/com/ajouevent/admin/dto/response/AdminAuthResponse.java
@@ -1,0 +1,13 @@
+package com.ajouevent.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AdminAuthResponse {
+    private Long id;
+}

--- a/src/main/java/com/ajouevent/admin/exception/ApiException.java
+++ b/src/main/java/com/ajouevent/admin/exception/ApiException.java
@@ -1,0 +1,24 @@
+package com.ajouevent.admin.exception;
+
+
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public int getDetailStatusCode() {
+        return errorCode.getCode();
+    }
+
+    public String getErrorMessage() {
+        return errorCode.getMessage();
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/ajouevent/admin/exception/ErrorCode.java
+++ b/src/main/java/com/ajouevent/admin/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.ajouevent.admin.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    USER_NOT_FOUND(404001, "존재하지 않는 관리자 계정입니다."),
+    USER_DUPLICATED(400001, "이미 사용 중인 이메일입니다."),
+    PASSWORD_NOT_CORRECT(400002, "비밀번호가 일치하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/ajouevent/admin/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ajouevent/admin/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.ajouevent.admin.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<Map<String, Object>> handleApiException(ApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(400)
+                .body(Map.of(
+                        "code", errorCode.getCode(),
+                        "message", errorCode.getMessage()
+                ));
+    }
+}

--- a/src/main/java/com/ajouevent/admin/repository/AdminUserRepository.java
+++ b/src/main/java/com/ajouevent/admin/repository/AdminUserRepository.java
@@ -1,0 +1,11 @@
+package com.ajouevent.admin.repository;
+
+import com.ajouevent.admin.domain.AdminUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminUserRepository extends JpaRepository<AdminUser, Long> {
+    Optional<AdminUser> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/ajouevent/admin/service/AdminUserService.java
+++ b/src/main/java/com/ajouevent/admin/service/AdminUserService.java
@@ -1,0 +1,10 @@
+package com.ajouevent.admin.service;
+
+import com.ajouevent.admin.dto.request.SignUpRequest;
+import com.ajouevent.admin.dto.request.LoginRequest;
+import com.ajouevent.admin.dto.response.AdminAuthResponse;
+
+public interface AdminUserService {
+    AdminAuthResponse signUp(SignUpRequest request);
+    AdminAuthResponse login(LoginRequest request);
+}

--- a/src/main/java/com/ajouevent/admin/service/AdminUserServiceImpl.java
+++ b/src/main/java/com/ajouevent/admin/service/AdminUserServiceImpl.java
@@ -4,8 +4,9 @@ import com.ajouevent.admin.domain.AdminUser;
 import com.ajouevent.admin.dto.request.LoginRequest;
 import com.ajouevent.admin.dto.request.SignUpRequest;
 import com.ajouevent.admin.dto.response.AdminAuthResponse;
+import com.ajouevent.admin.exception.ApiException;
+import com.ajouevent.admin.exception.ErrorCode;
 import com.ajouevent.admin.repository.AdminUserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     @Override
     public AdminAuthResponse signUp(SignUpRequest request) {
         if (adminUserRepository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new ApiException(ErrorCode.USER_DUPLICATED);
         }
 
         AdminUser adminUser = AdminUser.builder()
@@ -38,12 +39,11 @@ public class AdminUserServiceImpl implements AdminUserService {
     @Override
     public AdminAuthResponse login(LoginRequest request) {
         AdminUser user = adminUserRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 관리자 계정입니다."));
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new ApiException(ErrorCode.PASSWORD_NOT_CORRECT);
         }
-
         return new AdminAuthResponse(user.getId());
     }
 

--- a/src/main/java/com/ajouevent/admin/service/AdminUserServiceImpl.java
+++ b/src/main/java/com/ajouevent/admin/service/AdminUserServiceImpl.java
@@ -1,0 +1,50 @@
+package com.ajouevent.admin.service;
+
+import com.ajouevent.admin.domain.AdminUser;
+import com.ajouevent.admin.dto.request.LoginRequest;
+import com.ajouevent.admin.dto.request.SignUpRequest;
+import com.ajouevent.admin.dto.response.AdminAuthResponse;
+import com.ajouevent.admin.repository.AdminUserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminUserServiceImpl implements AdminUserService {
+
+    private final AdminUserRepository adminUserRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public AdminAuthResponse signUp(SignUpRequest request) {
+        if (adminUserRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        AdminUser adminUser = AdminUser.builder()
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .userNickname(request.getUserNickname())
+                .build();
+
+        AdminUser saved = adminUserRepository.save(adminUser);
+        return new AdminAuthResponse(saved.getId());
+    }
+
+    @Override
+    public AdminAuthResponse login(LoginRequest request) {
+        AdminUser user = adminUserRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 관리자 계정입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return new AdminAuthResponse(user.getId());
+    }
+
+}

--- a/src/main/resources/application.proterties
+++ b/src/main/resources/application.proterties
@@ -1,0 +1,12 @@
+# H2 메모리 DB 설정
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA 설정
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+# H2 콘솔 (선택)
+spring.h2.console.enabled=true


### PR DESCRIPTION
## 도메인
'관리자가 알림을 받아보고, 글을 쓰고 할 필요는 없고, 그저 '관리자'로만 존재하는게 맞다는 판단에 member엔터티에 role을 사용하지 않고,
adminUser 라는 엔터티를 만듦. 어드민 페이지에 인증처리만 담당하는 도메인임.
나머지 도메인들을 아주 이벤트 백에서 몇 개 긁어오기만 함.

## 서비스
뭔가 서비스 인터페이스 선언하고 만드는게 기모찌라서 그렇게 하기로 하자. 어떠노?

## 시큐리티컨피그
이건 비밀번호 디코더 뭐 컨피그할라고 빈등록(?) 해놓은건데 헷갈헷갈티비임. 잘못 건들이면 
implementation 'org.springframework.boot:spring-boot-starter-security' -> 얘가 api 잠궈버릴거임.

## 앤드포인트
노션에 정리 예정

## .Exception 패키지

![image](https://github.com/user-attachments/assets/08277433-37e1-4b24-9193-76194dc09c19)
예외 던지기
![image](https://github.com/user-attachments/assets/6fa7da49-088d-43f6-a42f-69a0cd1ab48b)

예외 시 JSON 응답 예제 -> 노션으로 각 앤드포인트 마다 정리 예정
![image](https://github.com/user-attachments/assets/ebda30a1-0658-41d3-b2b6-b2787e59eee7)
![image](https://github.com/user-attachments/assets/b344b09c-5c0d-4d96-a439-fefc32e2eb4a)

## DB
일단 런타임 h2 로 만들어놓았는데 properties 보면 있음. -> gitignore 할 예정
빨리빨리 기술 개발 하고 테스트 볼 때 로컬 도커로 db 띄워놓고 하는 방식으로 사용해봐도 좋을 것 같음.